### PR TITLE
convert chain config to interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/tendermint/tendermint v0.34.15
 	github.com/terra-money/core v0.5.14
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
+	gopkg.in/guregu/null.v4 v4.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1815,6 +1815,7 @@ github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/tyler-smith/go-bip39 v1.0.2/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v0.0.0-20181209151446-772ced7fd4c2/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/pkg/terra/chain.go
+++ b/pkg/terra/chain.go
@@ -2,7 +2,6 @@ package terra
 
 import (
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
-	"github.com/smartcontractkit/chainlink-terra/pkg/terra/config"
 )
 
 type ChainSet interface {
@@ -14,7 +13,7 @@ type Chain interface {
 	Service
 
 	ID() string
-	Config() config.ChainCfg
+	Config() Config
 	MsgEnqueuer() MsgEnqueuer
 	Reader() client.Reader
 }

--- a/pkg/terra/client/mocks/ReaderWriter.go
+++ b/pkg/terra/client/mocks/ReaderWriter.go
@@ -72,11 +72,11 @@ func (_m *ReaderWriter) Balance(addr types.AccAddress, denom string) (*types.Coi
 }
 
 // BatchSimulateUnsigned provides a mock function with given fields: msgs, sequence
-func (_m *ReaderWriter) BatchSimulateUnsigned(msgs []client.SimMsg, sequence uint64) (*client.BatchSimResults, error) {
+func (_m *ReaderWriter) BatchSimulateUnsigned(msgs client.SimMsgs, sequence uint64) (*client.BatchSimResults, error) {
 	ret := _m.Called(msgs, sequence)
 
 	var r0 *client.BatchSimResults
-	if rf, ok := ret.Get(0).(func([]client.SimMsg, uint64) *client.BatchSimResults); ok {
+	if rf, ok := ret.Get(0).(func(client.SimMsgs, uint64) *client.BatchSimResults); ok {
 		r0 = rf(msgs, sequence)
 	} else {
 		if ret.Get(0) != nil {
@@ -85,7 +85,7 @@ func (_m *ReaderWriter) BatchSimulateUnsigned(msgs []client.SimMsg, sequence uin
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([]client.SimMsg, uint64) error); ok {
+	if rf, ok := ret.Get(1).(func(client.SimMsgs, uint64) error); ok {
 		r1 = rf(msgs, sequence)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/terra/config.go
+++ b/pkg/terra/config.go
@@ -13,9 +13,8 @@ var DefaultConfigSet = ConfigSet{
 	// ~8s per block, so ~80s until we give up on the tx getting confirmed
 	// Anecdotally it appears anything more than 4 blocks would be an extremely long wait.
 	BlocksUntilTxTimeout:  10,
-	ConfirmMaxPolls:       100,
 	ConfirmPollPeriod:     time.Second,
-	FallbackGasPriceULuna: sdk.MustNewDecFromStr("0.01"),
+	FallbackGasPriceULuna: sdk.MustNewDecFromStr("0.015"),
 	GasLimitMultiplier:    1.5,
 	// The max gas limit per block is 1_000_000_000
 	// https://github.com/terra-money/core/blob/d6037b9a12c8bf6b09fe861c8ad93456aac5eebb/app/legacy/migrate.go#L69.
@@ -24,14 +23,13 @@ var DefaultConfigSet = ConfigSet{
 	// There appears to be no gas limit per tx, only per block, so theoretically
 	// we could include 1000 msgs which use up to 1M gas.
 	// To be conservative and since the number of messages we'd
-	// have in a batch on average roughly correponds to the number of terra ocr jobs we're running (do not expect more than 100),
+	// have in a batch on average roughly corresponds to the number of terra ocr jobs we're running (do not expect more than 100),
 	// we can set a max msgs per batch of 100.
 	MaxMsgsPerBatch: 100,
 }
 
 type Config interface {
 	BlocksUntilTxTimeout() int64
-	ConfirmMaxPolls() int64
 	ConfirmPollPeriod() time.Duration
 	FallbackGasPriceULuna() sdk.Dec
 	GasLimitMultiplier() float64
@@ -44,7 +42,6 @@ type Config interface {
 // ConfigSet has configuration fields for default sets and testing.
 type ConfigSet struct {
 	BlocksUntilTxTimeout  int64
-	ConfirmMaxPolls       int64
 	ConfirmPollPeriod     time.Duration
 	FallbackGasPriceULuna sdk.Dec
 	GasLimitMultiplier    float64
@@ -83,16 +80,6 @@ func (c *config) BlocksUntilTxTimeout() int64 {
 		return ch.Int64
 	}
 	return c.defaults.BlocksUntilTxTimeout
-}
-
-func (c *config) ConfirmMaxPolls() int64 {
-	c.chainMu.RLock()
-	ch := c.chain.ConfirmMaxPolls
-	c.chainMu.RUnlock()
-	if ch.Valid {
-		return ch.Int64
-	}
-	return c.defaults.ConfirmMaxPolls
 }
 
 func (c *config) ConfirmPollPeriod() time.Duration {

--- a/pkg/terra/config.go
+++ b/pkg/terra/config.go
@@ -1,0 +1,54 @@
+package terra
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var DefaultConfigSet = ConfigSet{
+	ConfirmMaxPolls:       100,
+	ConfirmPollPeriod:     time.Second,
+	FallbackGasPriceULuna: sdk.MustNewDecFromStr("0.01"),
+	GasLimitMultiplier:    1.5,
+}
+
+type Config interface {
+	ConfirmMaxPolls() int64
+	ConfirmPollPeriod() time.Duration
+	FallbackGasPriceULuna() sdk.Dec
+	GasLimitMultiplier() float64
+}
+
+// ConfigSet has configuration fields for default sets and testing.
+type ConfigSet struct {
+	ConfirmMaxPolls       int64
+	ConfirmPollPeriod     time.Duration
+	FallbackGasPriceULuna sdk.Dec
+	GasLimitMultiplier    float64
+}
+
+// Config returns a Config backed by this ConfigSet.
+func (s ConfigSet) Config() Config {
+	return &configSet{s}
+}
+
+type configSet struct {
+	s ConfigSet
+}
+
+func (c *configSet) ConfirmMaxPolls() int64 {
+	return c.s.ConfirmMaxPolls
+}
+
+func (c *configSet) ConfirmPollPeriod() time.Duration {
+	return c.s.ConfirmPollPeriod
+}
+
+func (c *configSet) FallbackGasPriceULuna() sdk.Dec {
+	return c.s.FallbackGasPriceULuna
+}
+
+func (c *configSet) GasLimitMultiplier() float64 {
+	return c.s.GasLimitMultiplier
+}

--- a/pkg/terra/config.go
+++ b/pkg/terra/config.go
@@ -7,25 +7,42 @@ import (
 )
 
 var DefaultConfigSet = ConfigSet{
+	// ~8s per block, so ~80s until we give up on the tx getting confirmed
+	// Anecdotally it appears anything more than 4 blocks would be an extremely long wait.
+	BlocksUntilTxTimeout:  10,
 	ConfirmMaxPolls:       100,
 	ConfirmPollPeriod:     time.Second,
 	FallbackGasPriceULuna: sdk.MustNewDecFromStr("0.01"),
 	GasLimitMultiplier:    1.5,
+	// The max gas limit per block is 1_000_000_000
+	// https://github.com/terra-money/core/blob/d6037b9a12c8bf6b09fe861c8ad93456aac5eebb/app/legacy/migrate.go#L69.
+	// The max msg size is 10KB https://github.com/terra-money/core/blob/d6037b9a12c8bf6b09fe861c8ad93456aac5eebb/x/wasm/types/params.go#L15.
+	// Our msgs are only OCR reports for now, which will not exceed that size.
+	// There appears to be no gas limit per tx, only per block, so theoretically
+	// we could include 1000 msgs which use up to 1M gas.
+	// To be conservative and since the number of messages we'd
+	// have in a batch on average roughly correponds to the number of terra ocr jobs we're running (do not expect more than 100),
+	// we can set a max msgs per batch of 100.
+	MaxMsgsPerBatch: 100,
 }
 
 type Config interface {
+	BlocksUntilTxTimeout() int64
 	ConfirmMaxPolls() int64
 	ConfirmPollPeriod() time.Duration
 	FallbackGasPriceULuna() sdk.Dec
 	GasLimitMultiplier() float64
+	MaxMsgsPerBatch() int64
 }
 
 // ConfigSet has configuration fields for default sets and testing.
 type ConfigSet struct {
+	BlocksUntilTxTimeout  int64
 	ConfirmMaxPolls       int64
 	ConfirmPollPeriod     time.Duration
 	FallbackGasPriceULuna sdk.Dec
 	GasLimitMultiplier    float64
+	MaxMsgsPerBatch       int64
 }
 
 // Config returns a Config backed by this ConfigSet.
@@ -35,6 +52,10 @@ func (s ConfigSet) Config() Config {
 
 type configSet struct {
 	s ConfigSet
+}
+
+func (c *configSet) BlocksUntilTxTimeout() int64 {
+	return c.s.BlocksUntilTxTimeout
 }
 
 func (c *configSet) ConfirmMaxPolls() int64 {
@@ -51,4 +72,8 @@ func (c *configSet) FallbackGasPriceULuna() sdk.Dec {
 
 func (c *configSet) GasLimitMultiplier() float64 {
 	return c.s.GasLimitMultiplier
+}
+
+func (c *configSet) MaxMsgsPerBatch() int64 {
+	return c.s.MaxMsgsPerBatch
 }

--- a/pkg/terra/config/config.go
+++ b/pkg/terra/config/config.go
@@ -1,7 +1,0 @@
-package config
-
-// ChainCfg is configuration parameters for a terra chain.
-type ChainCfg struct {
-	FallbackGasPriceULuna string
-	GasLimitMultiplier    float64
-}

--- a/pkg/terra/config_test.go
+++ b/pkg/terra/config_test.go
@@ -1,7 +1,9 @@
 package terra
 
 import (
+	"github.com/smartcontractkit/chainlink/core/store/models"
 	"testing"
+	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
@@ -18,18 +20,22 @@ func TestConfig(t *testing.T) {
 	lggr := new(mocks.Logger)
 	lggr.On("Warnf", mock.Anything, "FallbackGasPriceULuna", "not-a-number", mock.Anything, mock.Anything).Once()
 	cfg := NewConfig(db.ChainCfg{}, def, lggr)
+	assert.Equal(t, def.BlockRate, cfg.BlockRate())
 	assert.Equal(t, def.BlocksUntilTxTimeout, cfg.BlocksUntilTxTimeout())
 	assert.Equal(t, def.ConfirmPollPeriod, cfg.ConfirmPollPeriod())
 	assert.Equal(t, def.FallbackGasPriceULuna, cfg.FallbackGasPriceULuna())
 	assert.Equal(t, def.GasLimitMultiplier, cfg.GasLimitMultiplier())
 	assert.Equal(t, def.MaxMsgsPerBatch, cfg.MaxMsgsPerBatch())
 
+	minute := models.MustMakeDuration(time.Minute)
 	updated := db.ChainCfg{
+		BlockRate:             &minute,
 		BlocksUntilTxTimeout:  null.IntFrom(1000),
 		FallbackGasPriceULuna: null.StringFrom("5.6"),
 	}
 	cfg.Update(updated)
 	assert.Equal(t, updated.BlocksUntilTxTimeout.Int64, cfg.BlocksUntilTxTimeout())
+	assert.Equal(t, updated.BlockRate.Duration(), cfg.BlockRate())
 	assert.Equal(t, def.ConfirmPollPeriod, cfg.ConfirmPollPeriod())
 	assert.Equal(t, sdk.MustNewDecFromStr(updated.FallbackGasPriceULuna.String), cfg.FallbackGasPriceULuna())
 	assert.Equal(t, def.GasLimitMultiplier, cfg.GasLimitMultiplier())

--- a/pkg/terra/config_test.go
+++ b/pkg/terra/config_test.go
@@ -19,7 +19,6 @@ func TestConfig(t *testing.T) {
 	lggr.On("Warnf", mock.Anything, "FallbackGasPriceULuna", "not-a-number", mock.Anything, mock.Anything).Once()
 	cfg := NewConfig(db.ChainCfg{}, def, lggr)
 	assert.Equal(t, def.BlocksUntilTxTimeout, cfg.BlocksUntilTxTimeout())
-	assert.Equal(t, def.ConfirmMaxPolls, cfg.ConfirmMaxPolls())
 	assert.Equal(t, def.ConfirmPollPeriod, cfg.ConfirmPollPeriod())
 	assert.Equal(t, def.FallbackGasPriceULuna, cfg.FallbackGasPriceULuna())
 	assert.Equal(t, def.GasLimitMultiplier, cfg.GasLimitMultiplier())
@@ -31,7 +30,6 @@ func TestConfig(t *testing.T) {
 	}
 	cfg.Update(updated)
 	assert.Equal(t, updated.BlocksUntilTxTimeout.Int64, cfg.BlocksUntilTxTimeout())
-	assert.Equal(t, def.ConfirmMaxPolls, cfg.ConfirmMaxPolls())
 	assert.Equal(t, def.ConfirmPollPeriod, cfg.ConfirmPollPeriod())
 	assert.Equal(t, sdk.MustNewDecFromStr(updated.FallbackGasPriceULuna.String), cfg.FallbackGasPriceULuna())
 	assert.Equal(t, def.GasLimitMultiplier, cfg.GasLimitMultiplier())

--- a/pkg/terra/config_test.go
+++ b/pkg/terra/config_test.go
@@ -1,0 +1,45 @@
+package terra
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gopkg.in/guregu/null.v4"
+
+	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+	"github.com/smartcontractkit/chainlink-terra/pkg/terra/mocks"
+)
+
+func TestConfig(t *testing.T) {
+	def := DefaultConfigSet
+
+	lggr := new(mocks.Logger)
+	lggr.On("Warnf", mock.Anything, "FallbackGasPriceULuna", "not-a-number", mock.Anything, mock.Anything).Once()
+	cfg := NewConfig(db.ChainCfg{}, def, lggr)
+	assert.Equal(t, def.BlocksUntilTxTimeout, cfg.BlocksUntilTxTimeout())
+	assert.Equal(t, def.ConfirmMaxPolls, cfg.ConfirmMaxPolls())
+	assert.Equal(t, def.ConfirmPollPeriod, cfg.ConfirmPollPeriod())
+	assert.Equal(t, def.FallbackGasPriceULuna, cfg.FallbackGasPriceULuna())
+	assert.Equal(t, def.GasLimitMultiplier, cfg.GasLimitMultiplier())
+	assert.Equal(t, def.MaxMsgsPerBatch, cfg.MaxMsgsPerBatch())
+
+	updated := db.ChainCfg{
+		BlocksUntilTxTimeout:  null.IntFrom(1000),
+		FallbackGasPriceULuna: null.StringFrom("5.6"),
+	}
+	cfg.Update(updated)
+	assert.Equal(t, updated.BlocksUntilTxTimeout.Int64, cfg.BlocksUntilTxTimeout())
+	assert.Equal(t, def.ConfirmMaxPolls, cfg.ConfirmMaxPolls())
+	assert.Equal(t, def.ConfirmPollPeriod, cfg.ConfirmPollPeriod())
+	assert.Equal(t, sdk.MustNewDecFromStr(updated.FallbackGasPriceULuna.String), cfg.FallbackGasPriceULuna())
+	assert.Equal(t, def.GasLimitMultiplier, cfg.GasLimitMultiplier())
+	assert.Equal(t, def.MaxMsgsPerBatch, cfg.MaxMsgsPerBatch())
+
+	updated = db.ChainCfg{
+		FallbackGasPriceULuna: null.StringFrom("not-a-number"),
+	}
+	cfg.Update(updated)
+	assert.Equal(t, def.FallbackGasPriceULuna, cfg.FallbackGasPriceULuna())
+}

--- a/pkg/terra/db/db.go
+++ b/pkg/terra/db/db.go
@@ -32,7 +32,6 @@ type Node struct {
 
 type ChainCfg struct {
 	BlocksUntilTxTimeout  null.Int
-	ConfirmMaxPolls       null.Int
 	ConfirmPollPeriod     *models.Duration
 	FallbackGasPriceULuna null.String
 	GasLimitMultiplier    null.Float
@@ -77,7 +76,7 @@ type Msg struct {
 	ChainID    string `db:"terra_chain_id"`
 	ContractID string
 	State      State
-	Raw        []byte
+	Raw        []byte // serialized msg
 	TxHash     *string
 	CreatedAt  time.Time
 	UpdatedAt  time.Time

--- a/pkg/terra/db/db.go
+++ b/pkg/terra/db/db.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+
+	"github.com/smartcontractkit/chainlink/core/store/models"
+)
+
+type Chain struct {
+	ID        string
+	Nodes     []Node
+	Cfg       ChainCfg
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	Enabled   bool
+}
+
+type Node struct {
+	ID            int32
+	Name          string
+	TerraChainID  string
+	TendermintURL string `db:"tendermint_url"`
+	FCDURL        string `db:"fcd_url"`
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type ChainCfg struct {
+	BlocksUntilTxTimeout  null.Int
+	ConfirmMaxPolls       null.Int
+	ConfirmPollPeriod     *models.Duration
+	FallbackGasPriceULuna null.String
+	GasLimitMultiplier    null.Float
+	MaxMsgsPerBatch       null.Int
+}
+
+func (c *ChainCfg) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+
+	return json.Unmarshal(b, c)
+}
+
+func (c ChainCfg) Value() (driver.Value, error) {
+	return json.Marshal(c)
+}

--- a/pkg/terra/db/db.go
+++ b/pkg/terra/db/db.go
@@ -31,6 +31,7 @@ type Node struct {
 }
 
 type ChainCfg struct {
+	BlockRate             *models.Duration
 	BlocksUntilTxTimeout  null.Int
 	ConfirmPollPeriod     *models.Duration
 	FallbackGasPriceULuna null.String

--- a/pkg/terra/db/db.go
+++ b/pkg/terra/db/db.go
@@ -51,3 +51,34 @@ func (c *ChainCfg) Scan(value interface{}) error {
 func (c ChainCfg) Value() (driver.Value, error) {
 	return json.Marshal(c)
 }
+
+// State represents the state of a given terra msg
+// Happy path: Unstarted->Broadcasted->Confirmed
+type State string
+
+var (
+	// Unstarted means queued but not processed.
+	// Valid next states: Broadcasted, Errored (sim fails)
+	Unstarted State = "unstarted"
+	// Broadcasted means included in the mempool of a node.
+	// Valid next states: Confirmed (found onchain), Errored (tx expired waiting for confirmation)
+	Broadcasted State = "broadcasted"
+	// Confirmed means we're able to retrieve the txhash of the tx which broadcasted the msg.
+	// Valid next states: none, terminal state
+	Confirmed State = "confirmed"
+	// Errored means the msg reverted in simulation OR the tx containing the message timed out waiting to be confirmed
+	// TODO: when we add gas bumping, we'll address that timeout case
+	// Valid next states, none, terminal state
+	Errored State = "errored"
+)
+
+type Msg struct {
+	ID         int64
+	ChainID    string `db:"terra_chain_id"`
+	ContractID string
+	State      State
+	Raw        []byte
+	TxHash     *string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}

--- a/pkg/terra/median_contract.go
+++ b/pkg/terra/median_contract.go
@@ -18,9 +18,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 )
 
-const (
-	BlockRate = 5 // 1 block/5 seconds
-)
+const BlockRateSeconds = 8 // 1 block/8 seconds
 
 // MedianContract interface
 var _ median.MedianContract = (*MedianContract)(nil)
@@ -103,7 +101,7 @@ func (ct *MedianContract) LatestRoundRequested(ctx context.Context, lookback tim
 		err = blkErr
 		return
 	}
-	blockNum := uint64(latestBlock.Block.Header.Height) - uint64(lookback.Seconds())/BlockRate
+	blockNum := uint64(latestBlock.Block.Header.Height) - uint64(lookback.Seconds())/BlockRateSeconds
 	res, err := ct.chainReader.TxsEvents([]string{fmt.Sprintf("tx.height>=%d", blockNum+1), fmt.Sprintf("wasm-new_round.contract_address='%s'", ct.address.String())})
 	if err != nil {
 		return

--- a/pkg/terra/relay.go
+++ b/pkg/terra/relay.go
@@ -113,7 +113,7 @@ func (r *Relayer) NewOCR2Provider(externalJobID uuid.UUID, s interface{}) (relay
 
 	reportCodec := ReportCodec{}
 	transmitter := NewContractTransmitter(externalJobID.String(), contractAddr, senderAddr, msgEnqueuer, chainReader, r.lggr)
-	median := NewMedianContract(contractAddr, chainReader, r.lggr, transmitter)
+	median := NewMedianContract(contractAddr, chainReader, r.lggr, transmitter, chain.Config())
 
 	return ocr2Provider{
 		digester:       digester,

--- a/pkg/terra/types.go
+++ b/pkg/terra/types.go
@@ -2,6 +2,9 @@ package terra
 
 import (
 	"fmt"
+	"github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
+	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+	"github.com/smartcontractkit/terra.go/msg"
 	"strings"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
@@ -62,4 +65,32 @@ type LatestTransmissionDetails struct {
 type LatestConfigDigestAndEpoch struct {
 	ConfigDigest types.ConfigDigest `json:"config_digest"`
 	Epoch        uint32             `json:"epoch"`
+}
+
+type Msg struct {
+	db.Msg
+
+	// In memory only
+	ExecuteContract *msg.ExecuteContract
+}
+
+type Msgs []Msg
+
+func (tms Msgs) GetSimMsgs() client.SimMsgs {
+	var msgs []client.SimMsg
+	for i := range tms {
+		msgs = append(msgs, client.SimMsg{
+			ID:  tms[i].ID,
+			Msg: tms[i].ExecuteContract,
+		})
+	}
+	return msgs
+}
+
+func (tms Msgs) GetIDs() []int64 {
+	ids := make([]int64, len(tms))
+	for i := range tms {
+		ids[i] = tms[i].ID
+	}
+	return ids
 }


### PR DESCRIPTION
- Convert to an interface for live reconfiguration, and add four more fields.
- Move some types from core