### PR TITLE
fix abstract command abi validation for cw-plus contracts

### DIFF
--- a/packages-ts/gauntlet-terra-contracts/src/commands/abstract/index.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/abstract/index.ts
@@ -34,16 +34,21 @@ export const parseInstruction = async (instruction: string, inputVersion: string
 
   const isValidFunction = (abi: TerraABI, functionName: string): boolean => {
     // Check against ABI if method exists
-    const availableFunctions = [...(abi.query.oneOf || []), ...(abi.execute.oneOf || [])].reduce((agg, prop) => {
+    const availableFunctions = [
+      ...(abi.query.oneOf || abi.query.anyOf || []),
+      ...(abi.execute.oneOf || abi.query.anyOf || []),
+    ].reduce((agg, prop) => {
       if (prop?.required && prop.required.length > 0) return [...agg, ...prop.required]
       if (prop?.enum && prop.enum.length > 0) return [...agg, ...prop.enum]
       return [...agg]
     }, [])
+    logger.debug(`Available functions on this contract: ${availableFunctions}`)
     return availableFunctions.includes(functionName)
   }
 
   const isQueryFunction = (abi: TerraABI, functionName: string) => {
-    return abi.query.oneOf.find((queryAbi: any) => {
+    const functionList = abi.query.oneOf || abi.query.anyOf
+    return functionList.find((queryAbi: any) => {
       if (queryAbi.enum) return queryAbi.enum.includes(functionName)
       if (queryAbi.required) return queryAbi.required.includes(functionName)
       return false

--- a/packages-ts/gauntlet-terra-contracts/src/lib/contracts.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/contracts.ts
@@ -64,7 +64,7 @@ export const getContractCode = async (contractId: CONTRACT_LIST, version): Promi
       default:
         url = `https://github.com/smartcontractkit/chainlink-terra/releases/download/${version}/${contractId}.wasm`
     }
-    console.log(`Fetching ${url}...`)
+    logger.loading(`Fetching ${url}...`)
     const response = await fetch(url)
     const body = await response.arrayBuffer()
     return Buffer.from(body).toString('base64')


### PR DESCRIPTION
The cw20_base, cw3_flex_multisig, and cw4_group contracts all use anyOf instead of oneOf.
This was preventing gauntlet to be able to directly call any functions on them.

For example, on current devel branch:
 `yarn gauntlet cw4_group:list_members --network=bombay-testnet terra152p5h4y80yl3yk7f5d5xw53qv9zmknr0rq3ext`

gives the error:
```
Terra Command execution error Error: Abstract: Function list_members for contract cw4_group not found
    at Object.parseInstruction (/Users/dominovaldano/workspace/chainlink-terra/packages-ts/gauntlet-terra-contracts/dist/commands/abstract/index.js:65:15)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Object.makeAbstractCommand [as makeCommand] (/Users/dominovaldano/workspace/chainlink-terra/packages-ts/gauntlet-terra-contracts/dist/commands/abstract/index.js:11:25)
    at async Router.find (/Users/dominovaldano/workspace/chainlink-terra/node_modules/@chainlink/gauntlet-core/dist/router.js:23:37)
    at async Object.exports.default [as executeCLI] (/Users/dominovaldano/workspace/chainlink-terra/node_modules/@chainlink/gauntlet-core/dist/cli.js:30:21)
    at async /Users/dominovaldano/workspace/chainlink-terra/packages-ts/gauntlet-terra-contracts/dist/index.js:22:9
```
These changes should fix the error.