### PR TITLE
update integrations framework tag to catch gauntlet exit code failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/smartcontractkit/chainlink v1.1.1-0.20220214133705-d9ee81244df2
 	github.com/smartcontractkit/chainlink-relay v0.0.0-20220208185145-f90ff8f9d79a
 	github.com/smartcontractkit/helmenv v1.0.36
-	github.com/smartcontractkit/integrations-framework v1.0.47
+	github.com/smartcontractkit/integrations-framework v1.0.48
 	github.com/smartcontractkit/libocr v0.0.0-20220125200954-5b957c834276
 	github.com/smartcontractkit/terra.go v1.0.3-0.20220108002221-62b39252ee16
 	github.com/stretchr/testify v1.7.0
@@ -89,7 +89,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b // indirect
-	github.com/ethereum/go-ethereum v1.10.11 // indirect
+	github.com/ethereum/go-ethereum v1.10.15 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -742,6 +742,7 @@ github.com/ethereum/go-ethereum v1.9.25/go.mod h1:vMkFiYLHI4tgPw4k2j4MHKoovchFE8
 github.com/ethereum/go-ethereum v1.10.4/go.mod h1:nEE0TP5MtxGzOMd7egIrbPJMQBnhVU3ELNxhBglIzhg=
 github.com/ethereum/go-ethereum v1.10.11 h1:KKIcwpmur9iTaVbR2dxlHu+peHVhU+/KX//NWvT1n9U=
 github.com/ethereum/go-ethereum v1.10.11/go.mod h1:W3yfrFyL9C1pHcwY5hmRHVDaorTiQxhYBkKyu5mEDHw=
+github.com/ethereum/go-ethereum v1.10.15 h1:E9o0kMbD8HXhp7g6UwIwntY05WTDheCGziMhegcBsQw=
 github.com/ethereum/go-ethereum v1.10.15/go.mod h1:W3yfrFyL9C1pHcwY5hmRHVDaorTiQxhYBkKyu5mEDHw=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/go.sum
+++ b/go.sum
@@ -742,6 +742,7 @@ github.com/ethereum/go-ethereum v1.9.25/go.mod h1:vMkFiYLHI4tgPw4k2j4MHKoovchFE8
 github.com/ethereum/go-ethereum v1.10.4/go.mod h1:nEE0TP5MtxGzOMd7egIrbPJMQBnhVU3ELNxhBglIzhg=
 github.com/ethereum/go-ethereum v1.10.11 h1:KKIcwpmur9iTaVbR2dxlHu+peHVhU+/KX//NWvT1n9U=
 github.com/ethereum/go-ethereum v1.10.11/go.mod h1:W3yfrFyL9C1pHcwY5hmRHVDaorTiQxhYBkKyu5mEDHw=
+github.com/ethereum/go-ethereum v1.10.15/go.mod h1:W3yfrFyL9C1pHcwY5hmRHVDaorTiQxhYBkKyu5mEDHw=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -2392,6 +2393,8 @@ github.com/smartcontractkit/integrations-framework v1.0.42/go.mod h1:TwDu8hGhQjt
 github.com/smartcontractkit/integrations-framework v1.0.44/go.mod h1:80yVYzfn5jz2ubPbDEuD7Kw0a55cS+o7tZlTHQu4VQc=
 github.com/smartcontractkit/integrations-framework v1.0.47 h1:cqTmqIEPRLXpfLrvhlOHl1nNZ9wFQuM/uPeazrvnDYw=
 github.com/smartcontractkit/integrations-framework v1.0.47/go.mod h1:vxO+yFQqnDh2Y707zensXk6JxJuRWrclJ/GdS/nS7jE=
+github.com/smartcontractkit/integrations-framework v1.0.48 h1:yeGBbu+AXlkR4kT4tKound3dItFMDMTczIirdX48lJ4=
+github.com/smartcontractkit/integrations-framework v1.0.48/go.mod h1:tWnoNol2k1yDW8ybOqK7QXFp6Xl2wnI6ASn398JPMJA=
 github.com/smartcontractkit/libocr v0.0.0-20201203233047-5d9b24f0cbb5/go.mod h1:bfdSuLnBWCkafDvPGsQ1V6nrXhg046gh227MKi4zkpc=
 github.com/smartcontractkit/libocr v0.0.0-20211117215336-6c9726817b2d/go.mod h1:nq3crM3wVqnyMlM/4ZydTuJ/WyCapAsOt7P94oRgSPg=
 github.com/smartcontractkit/libocr v0.0.0-20211202172717-e8b0536a572e/go.mod h1:nq3crM3wVqnyMlM/4ZydTuJ/WyCapAsOt7P94oRgSPg=

--- a/tests/e2e/chaos/chaos_test.go
+++ b/tests/e2e/chaos/chaos_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Solana chaos suite", func() {
 	})
 	AfterEach(func() {
 		By("Tearing down the environment", func() {
-			err := actions.TeardownSuite(state.Env, nil, "logs")
+			err := actions.TeardownSuite(state.Env, nil, "logs", nil)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})

--- a/tests/e2e/client.go
+++ b/tests/e2e/client.go
@@ -272,6 +272,11 @@ func (t *TerraLCDClient) CalculateTxGas(gasUsedValue *big.Int) (*big.Float, erro
 	panic("implement me")
 }
 
+// GetDefaultWallet gets the default wallet
+func (t *TerraLCDClient) GetDefaultWallet() *ifclient.EthereumWallet {
+	panic("implement me")
+}
+
 // Instantiate deploys WASM code and instantiating a contract
 func (t *TerraLCDClient) Instantiate(path string, instMsg interface{}) (string, error) {
 	sender := t.DefaultWallet.AccAddress

--- a/tests/e2e/smoke/gauntlet_test.go
+++ b/tests/e2e/smoke/gauntlet_test.go
@@ -82,10 +82,7 @@ var _ = Describe("Terra Gauntlet @gauntlet", func() {
 				"upload",
 				g.Flag("version", "local"),
 			}, []string{
-				"Error deploying flags code",
-				"Error deploying deviation_flagging_validator code",
-				"Error deploying ocr2 code",
-				"Error deploying access_controller code",
+				"Error deploying",
 				terraCommandError,
 			}, 10)
 			Expect(err).ShouldNot(HaveOccurred(), "Failed to upload contracts")

--- a/tests/e2e/smoke/gauntlet_test.go
+++ b/tests/e2e/smoke/gauntlet_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Terra Gauntlet @gauntlet", func() {
 
 	AfterEach(func() {
 		By("Tearing down the environment", func() {
-			err = actions.TeardownSuite(e, nil, "logs")
+			err = actions.TeardownSuite(e, nil, "logs", nil)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})

--- a/tests/e2e/smoke/ocr2_test.go
+++ b/tests/e2e/smoke/ocr2_test.go
@@ -1,12 +1,13 @@
 package smoke_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink-terra/tests/e2e/common"
 	tc "github.com/smartcontractkit/chainlink-terra/tests/e2e/smoke/common"
 	"github.com/smartcontractkit/integrations-framework/actions"
-	"time"
 )
 
 var _ = Describe("Terra OCRv2 @ocr", func() {
@@ -28,7 +29,7 @@ var _ = Describe("Terra OCRv2 @ocr", func() {
 
 	AfterEach(func() {
 		By("Tearing down the environment", func() {
-			err := actions.TeardownSuite(state.Env, nil, "logs")
+			err := actions.TeardownSuite(state.Env, nil, "logs", nil)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Since gauntlet-terra will be outputting error codes now, update the e2e test to throw when it does happen. Integrations-framework change for this https://github.com/smartcontractkit/integrations-framework/pull/219