### PR TITLE
fix proxy query for decimals, version, description

### DIFF
--- a/contracts/proxy-ocr2/src/integration_tests.rs
+++ b/contracts/proxy-ocr2/src/integration_tests.rs
@@ -37,6 +37,10 @@ mod mock {
     pub const LATEST_ROUND: Item<u32> = Item::new("latest_round");
     pub const ROUNDS: Map<U32Key, ocr2::state::Round> = Map::new("rounds");
 
+    pub const DECIMALS: u8 = 8;
+    pub const VERSION: &str = "0.0.0";
+    pub const NAME: &str = "mock test";
+
     pub fn contract() -> Box<dyn Contract<Empty>> {
         pub fn execute(
             deps: DepsMut,
@@ -74,6 +78,9 @@ mod mock {
                     let round = ROUNDS.load(deps.storage, latest_round.into())?;
                     to_binary(&round)
                 }
+                QueryMsg::Decimals => to_binary(&DECIMALS),
+                QueryMsg::Version => to_binary(&VERSION),
+                QueryMsg::Description => to_binary(&NAME.to_string()),
                 _ => unimplemented!(),
             }
         }
@@ -177,6 +184,30 @@ fn it_works() {
         .unwrap();
 
     assert_eq!(parse_round_id(latest_round.round_id), (1, 2));
+
+    // query decimals
+    let decimal: u8 = env
+        .router
+        .wrap()
+        .query_wasm_smart(&env.proxy_addr, &QueryMsg::Decimals)
+        .unwrap();
+    assert_eq!(decimal, mock::DECIMALS);
+
+    // query version
+    let version: String = env
+        .router
+        .wrap()
+        .query_wasm_smart(&env.proxy_addr, &QueryMsg::Version)
+        .unwrap();
+    assert_eq!(version, mock::VERSION.to_string());
+
+    // query description
+    let desc: String = env
+        .router
+        .wrap()
+        .query_wasm_smart(&env.proxy_addr, &QueryMsg::Description)
+        .unwrap();
+    assert_eq!(desc, mock::NAME.to_string());
 
     // query by round id, it should match latest round
     let round: Round = env

--- a/contracts/proxy-ocr2/src/lib.rs
+++ b/contracts/proxy-ocr2/src/lib.rs
@@ -187,24 +187,24 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<QueryResponse, Cont
     match msg {
         QueryMsg::Decimals => {
             let contract_address = CURRENT_PHASE.load(deps.storage)?.contract_address;
-            Ok(to_binary(&deps.querier.query_wasm_smart(
-                contract_address,
-                &ocr2::msg::QueryMsg::Decimals,
-            )?)?)
+            let decimals: u8 = deps
+                .querier
+                .query_wasm_smart(&contract_address, &ocr2::msg::QueryMsg::Decimals)?;
+            Ok(to_binary(&decimals)?)
         }
         QueryMsg::Version => {
             let contract_address = CURRENT_PHASE.load(deps.storage)?.contract_address;
-            Ok(to_binary(&deps.querier.query_wasm_smart(
-                contract_address,
-                &ocr2::msg::QueryMsg::Version,
-            )?)?)
+            let version: String = deps
+                .querier
+                .query_wasm_smart(contract_address, &ocr2::msg::QueryMsg::Version)?;
+            Ok(to_binary(&version)?)
         }
         QueryMsg::Description => {
             let contract_address = CURRENT_PHASE.load(deps.storage)?.contract_address;
-            Ok(to_binary(&deps.querier.query_wasm_smart(
-                contract_address,
-                &ocr2::msg::QueryMsg::Description,
-            )?)?)
+            let description: String = deps
+                .querier
+                .query_wasm_smart(contract_address, &ocr2::msg::QueryMsg::Description)?;
+            Ok(to_binary(&description)?)
         }
         QueryMsg::RoundData { round_id } => {
             let (phase_id, round_id) = parse_round_id(round_id);


### PR DESCRIPTION
Issue: certain queries on the proxy do not work (that should always work). Discovered when testing a deployed proxy and trying to query the decimals, description, and version in the block explorer using `"\"decimals\""` (for example)

Implemented test cases for querying those parameters which throws: 
```
thread 'integration_tests::it_works' panicked at 'called `Result::unwrap()` on an `Err` value: GenericErr { msg: "Querier contract error: Error parsing into type (): Invalid type" }', contracts/proxy-ocr2/src/integration_tests.rs:193:10
```

Solution: proxy query should be typed for proper unwrapping