### PR TITLE
feat: update OCR2 spec examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .direnv
 .vscode
+.idea
 target/
 artifacts/bin/
 tarpaulin-report.html

--- a/examples/spec/ocr2-bootstrap.spec.toml
+++ b/examples/spec/ocr2-bootstrap.spec.toml
@@ -1,12 +1,9 @@
-type            = "offchainreporting2"
+type            = "bootstrap"
 schemaVersion   = 1
 relay           = "terra"
 name            = "<insert job name here>"
 contractID      = "<insert terra ocr2 contract ID/address>"
-isBootstrapPeer = true
 p2pPeerID       = "<insert p2p id>"                   # optional, overrides P2P_PEER_ID
-ocrKeyBundleID  = "<insert terra ocr2 key bundle id>" # optional, overrides OCR2_KEY_BUNDLE_ID
-transmitterID   = "<insert terra transmitter key id>"
 
 [relayConfig]
 chainID  = "bombay-12"

--- a/examples/spec/ocr2-oracle-simple.spec.toml
+++ b/examples/spec/ocr2-oracle-simple.spec.toml
@@ -1,9 +1,9 @@
 type                 = "offchainreporting2"
+pluginType           = "median"
 schemaVersion        = 1
 relay                = "terra"
 name                 = "<insert job name here>"
 contractID           = "<insert terra ocr2 contract ID/address>"
-isBootstrapPeer      = false
 p2pBootstrapPeers    = ["somep2pkey@localhost-tcp:port"]   # optional, overrides P2PV2_BOOTSTRAPPERS
 p2pPeerID            = "<insert p2p id>"                   # optional, overrides P2P_PEER_ID
 ocrKeyBundleID       = "<insert terra ocr2 key bundle id>" # optional, overrides OCR2_KEY_BUNDLE_ID
@@ -15,6 +15,8 @@ observationSource    = """
     ds1_multiply [type="multiply" times=100000000]
     ds1 -> ds1_parse -> ds1_multiply
 """
+
+[pluginConfig]
 juelsPerFeeCoinSource = """
     // Fetch the LINK price from a data source
     // data source 1

--- a/examples/spec/ocr2-oracle.spec.toml
+++ b/examples/spec/ocr2-oracle.spec.toml
@@ -1,9 +1,9 @@
 type                 = "offchainreporting2"
+pluginType           = "median"
 schemaVersion        = 1
 relay                = "terra"
 name                 = "<insert job name here>"
 contractID           = "<insert terra ocr2 contract ID/address>"
-isBootstrapPeer      = false
 p2pBootstrapPeers    = ["somep2pkey@localhost-tcp:port"]   # optional, overrides P2PV2_BOOTSTRAPPERS
 p2pPeerID            = "<insert p2p id>"                   # optional, overrides P2P_PEER_ID
 ocrKeyBundleID       = "<insert terra ocr2 key bundle id>" # optional, overrides OCR2_KEY_BUNDLE_ID
@@ -26,6 +26,8 @@ observationSource    = """
     ds3 -> ds3_parse -> ds3_multiply -> answer
     answer [type="median" index=0]
 """
+
+[pluginConfig]
 juelsPerFeeCoinSource = """
     // Fetch the LINK price from three data sources
     // data source 1


### PR DESCRIPTION
Since the OCR2 specs have changed in the main Chainlink repo the spec examples will be out of date after the next update. This PR contains the modifies specs, please merge only after this repo contains the changes from Chainlink main.

The changes are fairly simple

- remove `isBootstrapPeer`
- move `juelsPerFeeCoinSource` to [pluginConfig], just like the relayConfig structure

OCR2 bootstrap jobs now have their own job type.