### PR TITLE
fix: create & sign simulated tx with local address instead of multisig

### DIFF
--- a/packages-ts/gauntlet-terra-cw-plus/src/commands/multisig.ts
+++ b/packages-ts/gauntlet-terra-cw-plus/src/commands/multisig.ts
@@ -35,8 +35,8 @@ export const wrapCommand = (command) => {
     }
 
     makeRawTransaction = async (signer: AccAddress, state?: State) => {
-      const message = await this.command.makeRawTransaction(this.multisig)
-      await this.command.simulate(this.multisig, [message])
+      const message = await this.command.makeRawTransaction(signer)
+      await this.command.simulate(signer, [message])
       logger.info(`Command simulation successful.`)
 
       const operations = {

--- a/packages-ts/gauntlet-terra/src/commands/internal/terra.ts
+++ b/packages-ts/gauntlet-terra/src/commands/internal/terra.ts
@@ -149,7 +149,8 @@ export default abstract class TerraCommand extends WriteCommand<TransactionRespo
 
   async simulate(signer: AccAddress, msgs: (MsgExecuteContract | MsgSend)[]): Promise<Number> {
     const account = await this.provider.auth.accountInfo(signer)
-    const signerData: SignerData = {
+    const signerOptions = {
+      address: signer,
       sequenceNumber: account.getSequenceNumber(),
       publicKey: account.getPublicKey(),
     }
@@ -160,7 +161,7 @@ export default abstract class TerraCommand extends WriteCommand<TransactionRespo
 
     // gas estimation successful => tx is valid (simulation is run under the hood)
     return await this.provider.tx.estimateGas(tx, {
-      signers: [signerData],
+      signers: [signerOptions],
     })
   }
 }


### PR DESCRIPTION
This was causing all multisig commands to fail, with an error message like this
    ('account sequence mismatch, expected 0, got 129: incorrect account sequence: invalid request')

I noticed two problems:

- tx messages were being created with local wallet, but signer set to multisig address
- 2nd argument of estimatedGas (signerOptions) was missing an address field; almost
but not identical to SignerData

Neither of these seemed to fix the problem by itself, but it works with both of these changes.  My best guess as to why, based on experimenting a bit with it:  The address field was getting set to null, due to being missing from the options, and the public key was also null because the multisig contract doesn't have any public key associated with it.   Either of these is enough to cause estimateGas() function to fall back on filling things in with an empty signature from a dummy key.  Which would be okay, but I guess this doesn't quite work because then it ignores the sequence number passed in and instead uses 0.