### PR TITLE
Fix - Multisig simulation

### DIFF
--- a/packages-ts/gauntlet-terra/src/commands/internal/terra.ts
+++ b/packages-ts/gauntlet-terra/src/commands/internal/terra.ts
@@ -149,14 +149,13 @@ export default abstract class TerraCommand extends WriteCommand<TransactionRespo
 
   async simulate(signer: AccAddress, msgs: (MsgExecuteContract | MsgSend)[]): Promise<Number> {
     const account = await this.provider.auth.accountInfo(signer)
+
     const signerData: SignerData = {
       sequenceNumber: account.getSequenceNumber(),
       publicKey: account.getPublicKey(),
     }
 
-    const tx = await this.wallet.createTx({
-      msgs,
-    })
+    const tx = await this.provider.tx.create([{ ...signerData, address: signer }], { msgs })
 
     // gas estimation successful => tx is valid (simulation is run under the hood)
     return await this.provider.tx.estimateGas(tx, {


### PR DESCRIPTION
Creating tx with the wallet was assigning account address and sequence by default based on loaded key.
For multisig transactions address and sequence have to correspond the multisig wallet.