### PR TITLE
Add default rdd setting, and require for acceptOwnership

### DIFF
--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/acceptOwnership.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/acceptOwnership.ts
@@ -15,10 +15,7 @@ const validateInput = (input: CommandInput): boolean => true
 const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => async (signer) => {
   const currentOwner = await context.provider.wasm.contractQuery(context.contract, 'owner' as any)
   if (!context.flags.rdd) {
-    logger.warn('No RDD flag provided. Accepting ownership without RDD check')
-    logger.info(`Accepting Ownership Transfer of contract with current owner ${currentOwner} to new owner `)
-    await prompt('Continue?')
-    return
+    throw new Error(`No RDD flag provided!`)
   }
   const contract = RDD.getContractFromRDD(RDD.getRDD(context.flags.rdd), context.contract)
   logger.info(`Accepting Ownership Transfer of contract of type "${contract.type}":

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/transferOwnership.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/transferOwnership.ts
@@ -36,12 +36,7 @@ const validateInput = (input: CommandInput): boolean => {
 const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => async () => {
   const currentOwner = await context.provider.wasm.contractQuery(context.contract, 'owner' as any)
   if (!context.flags.rdd) {
-    logger.warn('No RDD flag provided. Transferring without RDD check')
-    logger.info(
-      `Proposing Ownership Transfer of contract with current owner ${currentOwner} to new owner ${context.contractInput.to}`,
-    )
-    await prompt('Continue?')
-    return
+    throw new Error(`No RDD flag provided!`)
   }
   const contract = RDD.getContractFromRDD(RDD.getRDD(context.flags.rdd), context.contract)
   logger.info(`Proposing Ownership Transfer of contract of type "${contract.type}":

--- a/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
@@ -2,4 +2,5 @@ export const defaultFlags = {
   delta: 'delta.json',
   codeIdsPath: './codeIds',
   artifactsPath: './artifacts',
+  rdd: '../reference-data-directory/directory-terra-mainnet.json',
 }


### PR DESCRIPTION
Minor changes related to -rdd gauntlet flag (suggested during multisig review):

1. Will default to "../reference-data-directory/directory-terra-mainnet.json" if not passed explicitly
2. acceptOwnership & transferOwnership will throw Error instead of warn, if there is no rdd flag

In theory, the first one should make it so the second one can never happen, but this
is better behavior just in case.  And it matches what most other commands already do.