### PR TITLE
Read RDD from environment if --rdd flag is missing

### DIFF
--- a/packages-ts/gauntlet-terra-contracts/networks/.env.mainnet
+++ b/packages-ts/gauntlet-terra-contracts/networks/.env.mainnet
@@ -1,0 +1,11 @@
+NODE_URL=
+CHAIN_ID=columbus-5
+DEFAULT_GAS_PRICE=0.5
+RDD=../reference-data-directory/directory-terra-mainnet.json
+
+LINK=
+BILLING_ACCESS_CONTROLLER=
+REQUESTER_ACCESS_CONTROLLER=
+
+CW4_GROUP=
+CW3_FLEX_MULTISIG=

--- a/packages-ts/gauntlet-terra-contracts/networks/.env.testnet-bombay
+++ b/packages-ts/gauntlet-terra-contracts/networks/.env.testnet-bombay
@@ -1,6 +1,8 @@
 NODE_URL=https://bombay-lcd.terra.dev
 CHAIN_ID=bombay-12
 DEFAULT_GAS_PRICE=0.5
+RDD=../reference-data-directory/directory-terra-testnet-bombay.json
+
 LINK=terra167ccv2h0z7k0p8j6qpuzwsgu5au5qvfwgmkjsl
 BILLING_ACCESS_CONTROLLER=terra1anfm045fgautt6mm5wc7uk6njx30n3cwlgvv8p
 REQUESTER_ACCESS_CONTROLLER=terra1urknnpgcmgvptdmhdvex53hl72prwgcnn49t47

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposal/acceptProposal.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposal/acceptProposal.ts
@@ -24,8 +24,6 @@ const makeCommandInput = async (flags: any, args: string[]): Promise<CommandInpu
   if (flags.input) return flags.input as CommandInput
   const { rdd: rddPath, secret } = flags
 
-  if (!rddPath) throw new Error('RDD flag is required. Provide it with --rdd flag')
-
   const rdd = RDD.getRDD(rddPath)
   const contract = args[0]
 

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeConfig.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeConfig.ts
@@ -28,10 +28,6 @@ const makeCommandInput = async (flags: any, args: string[]): Promise<CommandInpu
 
   const { rdd: rddPath } = flags
 
-  if (!rddPath) {
-    throw new Error('No RDD flag provided!')
-  }
-
   const rdd = RDD.getRDD(rddPath)
   const contract = args[0]
   const aggregator = rdd.contracts[contract]

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeOffchainConfig.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeOffchainConfig.ts
@@ -94,10 +94,6 @@ const makeCommandInput = async (flags: any, args: string[]): Promise<CommandInpu
 
   const { rdd: rddPath, randomSecret } = flags
 
-  if (!rddPath) {
-    throw new Error('No RDD flag provided!')
-  }
-
   const rdd = RDD.getRDD(rddPath)
   const contract = args[0]
 

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/acceptOwnership.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/acceptOwnership.ts
@@ -14,9 +14,6 @@ const validateInput = (input: CommandInput): boolean => true
 
 const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => async (signer) => {
   const currentOwner = await context.provider.wasm.contractQuery(context.contract, 'owner' as any)
-  if (!context.flags.rdd) {
-    throw new Error(`No RDD flag provided!`)
-  }
   const contract = RDD.getContractFromRDD(RDD.getRDD(context.flags.rdd), context.contract)
   logger.info(`Accepting Ownership Transfer of contract of type "${contract.type}":
     - Contract: ${contract.address} ${contract.description ? '- ' + contract.description : ''}

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/transferOwnership.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/transferOwnership.ts
@@ -35,9 +35,6 @@ const validateInput = (input: CommandInput): boolean => {
 
 const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => async () => {
   const currentOwner = await context.provider.wasm.contractQuery(context.contract, 'owner' as any)
-  if (!context.flags.rdd) {
-    throw new Error(`No RDD flag provided!`)
-  }
   const contract = RDD.getContractFromRDD(RDD.getRDD(context.flags.rdd), context.contract)
   logger.info(`Proposing Ownership Transfer of contract of type "${contract.type}":
     - Contract: ${contract.address} ${contract.description ? '- ' + contract.description : ''}

--- a/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
@@ -2,7 +2,4 @@ export const defaultFlags = {
   delta: 'delta.json',
   codeIdsPath: './codeIds',
   artifactsPath: './artifacts',
-  // TODO: when enabled it will overwrite --rdd flag always, not just when -rdd flag missing
-  // Default path is set as next to chainlink-terra repo folder
-  // rdd: '../../../../../reference-data-directory/directory-${network}.json',
 }

--- a/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
@@ -1,3 +1,5 @@
+// Doesn't work as expected - https://github.com/smartcontractkit/chainlink-terra/issues/199
+// As a workaround, default RDD flag is set from env in gauntlet-terra/src/lib/rdd.ts
 export const defaultFlags = {
   delta: 'delta.json',
   codeIdsPath: './codeIds',

--- a/packages-ts/gauntlet-terra/src/lib/rdd.ts
+++ b/packages-ts/gauntlet-terra/src/lib/rdd.ts
@@ -4,6 +4,12 @@ import { join } from 'path'
 export const getRDD = (path: string, fileDescription: string = 'RDD'): any => {
   let pathToUse
   // test whether the file exists as a relative path or an absolute path
+  if (!path) {
+    path = process.env.RDD
+    if (!path) {
+      throw new Error(`No reference data directory specified!  Must pass --rdd flag or set RDD=...`)
+    }
+  }
   if (existsSync(path)) {
     pathToUse = path
   } else if (existsSync(join(process.cwd(), path))) {

--- a/packages-ts/gauntlet-terra/src/lib/rdd.ts
+++ b/packages-ts/gauntlet-terra/src/lib/rdd.ts
@@ -2,14 +2,13 @@ import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 
 export const getRDD = (path: string, fileDescription: string = 'RDD'): any => {
-  let pathToUse
-  // test whether the file exists as a relative path or an absolute path
+  path = path || process.env.RDD
   if (!path) {
-    path = process.env.RDD
-    if (!path) {
-      throw new Error(`No reference data directory specified!  Must pass --rdd flag or set RDD=...`)
-    }
+    throw new Error(`No reference data directory specified!  Must pass in the '--rdd' flag or set the 'RDD' env var`)
   }
+
+  // test whether the file exists as a relative path or an absolute path
+  let pathToUse
   if (existsSync(path)) {
     pathToUse = path
   } else if (existsSync(join(process.cwd(), path))) {


### PR DESCRIPTION
This is a second attempt at making the `--rdd` command line flag optional.
Simply adding it to the dictionary of `defaultNetworkFlags` returned by `loadDefaultFlags()` didn't work because of this gauntlet-core issue:
https://github.com/smartcontractkit/gauntlet-core/issues/48

In case that doesn't get fixed soon, or fixing it would break some existing desired behavior, this tries to read it from the flags first, and then falls back on reading it from RDD env var.

All the specific checks for a missing `--rdd` flag have been removed.  A single check in `getRDD()` should be enough to catch this problem for any command that uses the reference data directory.