### PR TITLE
Fix/ops review fixes

### DIFF
--- a/packages-ts/gauntlet-terra-contracts/networks/.env.mainnet
+++ b/packages-ts/gauntlet-terra-contracts/networks/.env.mainnet
@@ -1,0 +1,11 @@
+NODE_URL=
+CHAIN_ID=columbus-5
+DEFAULT_GAS_PRICE=0.5
+RDD=../reference-data-directory/directory-terra-mainnet.json
+
+LINK=
+BILLING_ACCESS_CONTROLLER=
+REQUESTER_ACCESS_CONTROLLER=
+
+CW4_GROUP=
+CW3_FLEX_MULTISIG=

--- a/packages-ts/gauntlet-terra-contracts/networks/.env.testnet-bombay
+++ b/packages-ts/gauntlet-terra-contracts/networks/.env.testnet-bombay
@@ -1,6 +1,8 @@
 NODE_URL=https://bombay-lcd.terra.dev
 CHAIN_ID=bombay-12
 DEFAULT_GAS_PRICE=0.5
+RDD=../reference-data-directory/directory-terra-testnet-bombay.json
+
 LINK=terra167ccv2h0z7k0p8j6qpuzwsgu5au5qvfwgmkjsl
 BILLING_ACCESS_CONTROLLER=terra1anfm045fgautt6mm5wc7uk6njx30n3cwlgvv8p
 REQUESTER_ACCESS_CONTROLLER=terra1urknnpgcmgvptdmhdvex53hl72prwgcnn49t47

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposal/acceptProposal.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposal/acceptProposal.ts
@@ -24,7 +24,17 @@ const makeCommandInput = async (flags: any, args: string[]): Promise<CommandInpu
   if (flags.input) return flags.input as CommandInput
   const { rdd: rddPath, secret } = flags
 
-  if (!rddPath) throw new Error('RDD flag is required. Provide it with --rdd flag')
+  if (!rddPath) {
+    throw new Error('RDD flag is required. Provide it with --rdd flag')
+  }
+
+  if (!secret) {
+    throw new Error('--secret flag is required.')
+  }
+
+  if (!process.env.SECRET) {
+    throw new Error('SECRET is not set in env!')
+  }
 
   const rdd = RDD.getRDD(rddPath)
   const contract = args[0]
@@ -57,7 +67,7 @@ const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => a
   logger.success('RDD Generated configuration matches with onchain proposal configuration')
 
   // Config in Proposal
-  const offchainConfigInProposal = await deserializeConfig(Buffer.from(proposal.offchain_config, 'base64'))
+  const offchainConfigInProposal = deserializeConfig(Buffer.from(proposal.offchain_config, 'base64'))
   const configInProposal = longsInObjToNumbers({
     ...offchainConfigInProposal,
     offchainPublicKeys: offchainConfigInProposal.offchainPublicKeys?.map((key) => Buffer.from(key).toString('hex')),
@@ -67,7 +77,7 @@ const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => a
   // Config in contract
   const event = await getLatestOCRConfigEvent(context.provider, context.contract)
   const offchainConfigInContract = event?.offchain_config
-    ? await deserializeConfig(Buffer.from(event.offchain_config[0], 'base64'))
+    ? deserializeConfig(Buffer.from(event.offchain_config[0], 'base64'))
     : ({} as OffchainConfig)
   const configInContract = longsInObjToNumbers({
     ...offchainConfigInContract,

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeConfig.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeConfig.ts
@@ -82,8 +82,7 @@ const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => a
     f: event?.f[0],
     transmitters: event?.transmitters,
     signers: event?.signers.map((s) => Buffer.from(s, 'hex').toString('base64')),
-    onchain_config: event?.onchain_config[0],
-    // todo: add payees to set_config event (https://github.com/smartcontractkit/chainlink-terra/issues/180)
+    payees: event?.payees,
   }
 
   const proposedConfig = {
@@ -91,7 +90,6 @@ const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => a
     transmitters: context.contractInput.transmitters,
     signers: context.contractInput.signers,
     payees: context.contractInput.payees,
-    onchain_config: context.contractInput.onchain_config,
   }
 
   logger.info('Review the proposed changes below: green - added, red - deleted.')

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeConfig.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/proposeConfig.ts
@@ -28,10 +28,6 @@ const makeCommandInput = async (flags: any, args: string[]): Promise<CommandInpu
 
   const { rdd: rddPath } = flags
 
-  if (!rddPath) {
-    throw new Error('No RDD flag provided!')
-  }
-
   const rdd = RDD.getRDD(rddPath)
   const contract = args[0]
   const aggregator = rdd.contracts[contract]

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/acceptOwnership.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/acceptOwnership.ts
@@ -14,9 +14,6 @@ const validateInput = (input: CommandInput): boolean => true
 
 const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => async (signer) => {
   const currentOwner = await context.provider.wasm.contractQuery(context.contract, 'owner' as any)
-  if (!context.flags.rdd) {
-    throw new Error(`No RDD flag provided!`)
-  }
   const contract = RDD.getContractFromRDD(RDD.getRDD(context.flags.rdd), context.contract)
   logger.info(`Accepting Ownership Transfer of contract of type "${contract.type}":
     - Contract: ${contract.address} ${contract.description ? '- ' + contract.description : ''}

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/transferOwnership.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ownership/transferOwnership.ts
@@ -35,9 +35,6 @@ const validateInput = (input: CommandInput): boolean => {
 
 const beforeExecute: BeforeExecute<CommandInput, ContractInput> = (context) => async () => {
   const currentOwner = await context.provider.wasm.contractQuery(context.contract, 'owner' as any)
-  if (!context.flags.rdd) {
-    throw new Error(`No RDD flag provided!`)
-  }
   const contract = RDD.getContractFromRDD(RDD.getRDD(context.flags.rdd), context.contract)
   logger.info(`Proposing Ownership Transfer of contract of type "${contract.type}":
     - Contract: ${contract.address} ${contract.description ? '- ' + contract.description : ''}

--- a/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/args.ts
@@ -1,8 +1,7 @@
+// Doesn't work as expected - https://github.com/smartcontractkit/chainlink-terra/issues/199
+// As a workaround, default RDD flag is set from env in gauntlet-terra/src/lib/rdd.ts
 export const defaultFlags = {
   delta: 'delta.json',
   codeIdsPath: './codeIds',
   artifactsPath: './artifacts',
-  // TODO: when enabled it will overwrite --rdd flag always, not just when -rdd flag missing
-  // Default path is set as next to chainlink-terra repo folder
-  // rdd: '../../../../../reference-data-directory/directory-${network}.json',
 }

--- a/packages-ts/gauntlet-terra-contracts/src/lib/encoding.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/encoding.ts
@@ -54,7 +54,7 @@ export const generateSecretWords = async (): Promise<string> => {
 }
 
 export const deserializeConfig = (buffer: Buffer): OffchainConfig => {
-  const proto = new Proto.Protobuf({ descriptor: descriptor })
+  const proto = new Proto.Protobuf({ descriptor })
   const offchain = proto.decode('offchainreporting2_config.OffchainConfigProto', buffer)
   const reportingPluginConfig = proto.decode(
     'offchainreporting2_config.ReportingPluginConfig',

--- a/packages-ts/gauntlet-terra/src/lib/rdd.ts
+++ b/packages-ts/gauntlet-terra/src/lib/rdd.ts
@@ -2,8 +2,13 @@ import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 
 export const getRDD = (path: string, fileDescription: string = 'RDD'): any => {
-  let pathToUse
+  path = path || process.env.RDD
+  if (!path) {
+    throw new Error(`No reference data directory specified!  Must pass in the '--rdd' flag or set the 'RDD' env var`)
+  }
+
   // test whether the file exists as a relative path or an absolute path
+  let pathToUse
   if (existsSync(path)) {
     pathToUse = path
   } else if (existsSync(join(process.cwd(), path))) {


### PR DESCRIPTION
Summary of changes:
- Serialize/deserialize rdd configuration before diff to work around default values removed by cosmos protobuf adaption (https://docs.cosmos.network/master/architecture/adr-027-deterministic-protobuf-serialization.html#implementation)
- `onchain_config` is removed from diff since it's always an empty string
- `configPublicKeys` removed from diff (diff is run on `sharedSecretEncryptions` instead)
- `payees` added to diff