### PR TITLE
Go back to go tooling for installing ginkgo on ci/linux

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Download Go Vendor Packages
         if: steps.cache-packages.outputs.cache-hit != 'true'
         run: nix develop -c make download
+      - name: Install Ginkgo CLI
+        run: |
+          nix develop -c make install
       - uses: actions/download-artifact@master
         with:
           name: artifacts

--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Download Go Vendor Packages
         if: steps.cache-packages.outputs.cache-hit != 'true'
         run: nix develop -c make download
+      - name: Install Ginkgo CLI
+        run: |
+          nix develop -c make install
       - uses: actions/download-artifact@master
         with:
           name: artifacts

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,10 @@ ifeq ($(OSFLAG),$(OSX))
 endif
 ifeq ($(OSFLAG),$(LINUX))
 	# install nix
+ifneq ($(CI),true)
 	sh <(curl -L https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install) --daemon --tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve --nix-extra-conf-file ./nix.conf
+endif
+	go install github.com/onsi/ginkgo/v2/ginkgo@v$(shell cat ./.tool-versions | grep ginkgo | sed -En "s/ginkgo.(.*)/\1/p")
 endif
 
 build_js:

--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,6 @@ pkgs.mkShell {
     delve
     golangci-lint
     gotools
-    ginkgo
 
     # NodeJS + TS
     nodePackages.typescript-language-server


### PR DESCRIPTION
It pulls the version for ginkgo directly from the ./.tool-versions file