### PR TITLE
e2e tests: map contract to nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tests/e2e/logs
 packages-ts/gauntlet-terra-contracts/networks/.env.test*
 tests/e2e/smoke/rdd/directory*
 tests/e2e/smoke/reports
+artifacts

--- a/tests/e2e/chaos/chaos_test.go
+++ b/tests/e2e/chaos/chaos_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var _ = Describe("Terra chaos suite", func() {
-	var state = common.NewOCRv2State(1)
+	var state = common.NewOCRv2State(1, 5)
 	BeforeEach(func() {
 		By("Deploying OCRv2 cluster", func() {
 			state.DeployCluster(5, "2s", true, utils.ContractsDir)

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -67,32 +67,6 @@ func stripKeyPrefix(key string) string {
 	return key
 }
 
-func createNodeKeys(nodes []client.Chainlink) ([]NodeKeysBundle, error) {
-	nkb := make([]NodeKeysBundle, 0)
-	for _, n := range nodes {
-		p2pkeys, err := n.ReadP2PKeys()
-		if err != nil {
-			return nil, err
-		}
-
-		peerID := p2pkeys.Data[0].Attributes.PeerID
-		txKey, err := n.CreateTxKey(ChainName)
-		if err != nil {
-			return nil, err
-		}
-		ocrKey, err := n.CreateOCR2Key(ChainName)
-		if err != nil {
-			return nil, err
-		}
-		nkb = append(nkb, NodeKeysBundle{
-			PeerID:  peerID,
-			OCR2Key: ocrKey,
-			TXKey:   txKey,
-		})
-	}
-	return nkb, nil
-}
-
 func CreateNodeKeysBundle(nodes []client.Chainlink) ([]NodeKeysBundle, error) {
 	nkb := make([]NodeKeysBundle, 0)
 	for _, n := range nodes {
@@ -165,51 +139,6 @@ func FundOracles(c client.BlockchainClient, nkb []NodeKeysBundle, amount *big.Fl
 	return nil
 }
 
-// DefaultOffChainConfigParamsFromNodes collects OCR2 keys and creates contracts.OffChainAggregatorV2Config
-func DefaultOffChainConfigParamsFromNodes(nodes []client.Chainlink) (contracts.OffChainAggregatorV2Config, []NodeKeysBundle, error) {
-	nkb, err := createNodeKeys(nodes)
-	if err != nil {
-		return contracts.OffChainAggregatorV2Config{}, nil, err
-	}
-	oi, err := createOracleIdentities(nkb[1:])
-	if err != nil {
-		return contracts.OffChainAggregatorV2Config{}, nil, err
-	}
-	s := make([]int, 0)
-	for range nodes[1:] {
-		s = append(s, 1)
-	}
-	faultyNodes := 0
-	if len(nodes[1:]) > 1 {
-		faultyNodes = len(nkb[1:])/3 - 1
-	}
-	if faultyNodes == 0 {
-		faultyNodes = 1
-	}
-	log.Warn().Int("Nodes", faultyNodes).Msg("Faulty nodes")
-	return contracts.OffChainAggregatorV2Config{
-		DeltaProgress: 2 * time.Second,
-		DeltaResend:   5 * time.Second,
-		DeltaRound:    1 * time.Second,
-		DeltaGrace:    500 * time.Millisecond,
-		DeltaStage:    10 * time.Second,
-		RMax:          3,
-		S:             s,
-		Oracles:       oi,
-		ReportingPluginConfig: median.OffchainConfig{
-			AlphaReportPPB: uint64(0),
-			AlphaAcceptPPB: uint64(0),
-		}.Encode(),
-		MaxDurationQuery:                        0,
-		MaxDurationObservation:                  500 * time.Millisecond,
-		MaxDurationReport:                       500 * time.Millisecond,
-		MaxDurationShouldAcceptFinalizedReport:  500 * time.Millisecond,
-		MaxDurationShouldTransmitAcceptedReport: 500 * time.Millisecond,
-		F:                                       faultyNodes,
-		OnchainConfig:                           []byte{},
-	}, nkb, nil
-}
-
 // OffChainConfigParamsFromNodes creates contracts.OffChainAggregatorV2Config
 func OffChainConfigParamsFromNodes(nodes []client.Chainlink, nkb []NodeKeysBundle) (contracts.OffChainAggregatorV2Config, error) {
 	oi, err := createOracleIdentities(nkb[1:])
@@ -271,41 +200,7 @@ func CreateTerraChainAndNode(nodes []client.Chainlink) error {
 	return nil
 }
 
-func CreateBridges(contracts []string, nodes []client.Chainlink, mock *client.MockserverClient) (map[string][]BridgeInfo, error) {
-	biMap := make(map[string][]BridgeInfo)
-	for _, contract := range contracts {
-		for _, n := range nodes {
-			nodeContractPairID, err := BuildNodeContractPairID(n, contract)
-			if err != nil {
-				return nil, err
-			}
-			sourceValueBridge := client.BridgeTypeAttributes{
-				Name:        nodeContractPairID,
-				URL:         fmt.Sprintf("%s/%s", mock.Config.ClusterURL, nodeContractPairID),
-				RequestData: "{}",
-			}
-			observationSource := client.ObservationSourceSpecBridge(sourceValueBridge)
-			err = n.CreateBridge(&sourceValueBridge)
-			if err != nil {
-				return nil, err
-			}
-			juelsBridge := client.BridgeTypeAttributes{
-				Name:        nodeContractPairID + "juels",
-				URL:         fmt.Sprintf("%s/juels", mock.Config.ClusterURL),
-				RequestData: "{}",
-			}
-			juelsSource := client.ObservationSourceSpecBridge(juelsBridge)
-			err = n.CreateBridge(&juelsBridge)
-			if err != nil {
-				return nil, err
-			}
-			biMap[contract] = append(biMap[contract], BridgeInfo{ObservationSource: observationSource, JuelsSource: juelsSource, RelayConfig: RelayConfig})
-		}
-	}
-	return biMap, nil
-}
-
-func CreateBridges2(ContractsIdxMapToContractsNodeInfo map[int]*ContractNodeInfo, mock *client.MockserverClient) error {
+func CreateBridges(ContractsIdxMapToContractsNodeInfo map[int]*ContractNodeInfo, mock *client.MockserverClient) error {
 	for i, nodesInfo := range ContractsIdxMapToContractsNodeInfo {
 		for _, node := range nodesInfo.Nodes {
 			nodeContractPairID, err := BuildNodeContractPairID(node, nodesInfo.OCR2Address)
@@ -339,41 +234,7 @@ func CreateBridges2(ContractsIdxMapToContractsNodeInfo map[int]*ContractNodeInfo
 	return nil
 }
 
-func CreateJobs(ocr2Addr string, bridgesInfo []BridgeInfo, nodes []client.Chainlink, nkb []NodeKeysBundle) error {
-	bootstrapPeers := []client.P2PData{
-		{
-			RemoteIP:   nodes[0].RemoteIP(),
-			RemotePort: "6690",
-			PeerID:     nkb[0].PeerID,
-		},
-	}
-	for nIdx, n := range nodes {
-		jobType := "offchainreporting2"
-		if nIdx == 0 {
-			jobType = "bootstrap"
-		}
-		jobSpec := &client.OCR2TaskJobSpec{
-			Name:                  fmt.Sprintf("terra-OCRv2-%d-%s", nIdx, uuid.NewV4().String()),
-			JobType:               jobType,
-			ContractID:            ocr2Addr,
-			Relay:                 ChainName,
-			RelayConfig:           bridgesInfo[nIdx].RelayConfig,
-			P2PPeerID:             nkb[nIdx].PeerID,
-			PluginType:            "median",
-			P2PBootstrapPeers:     bootstrapPeers,
-			OCRKeyBundleID:        nkb[nIdx].OCR2Key.Data.ID,
-			TransmitterID:         nkb[nIdx].TXKey.Data.ID,
-			ObservationSource:     bridgesInfo[nIdx].ObservationSource,
-			JuelsPerFeeCoinSource: bridgesInfo[nIdx].JuelsSource,
-		}
-		if _, err := n.CreateJob(jobSpec); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func CreateJobs2(contractNodeInfo *ContractNodeInfo) error {
+func CreateJobs(contractNodeInfo *ContractNodeInfo) error {
 	bootstrapPeers := []client.P2PData{
 		{
 			RemoteIP:   contractNodeInfo.Nodes[0].RemoteIP(),

--- a/tests/e2e/common/common.go
+++ b/tests/e2e/common/common.go
@@ -306,8 +306,6 @@ func CreateBridges(contracts []string, nodes []client.Chainlink, mock *client.Mo
 }
 
 func CreateBridges2(ContractsIdxMapToContractsNodeInfo map[int]*ContractNodeInfo, mock *client.MockserverClient) error {
-	biMap := make(map[string][]BridgeInfo)
-
 	for i, nodesInfo := range ContractsIdxMapToContractsNodeInfo {
 		for _, node := range nodesInfo.Nodes {
 			nodeContractPairID, err := BuildNodeContractPairID(node, nodesInfo.OCR2Address)
@@ -335,7 +333,6 @@ func CreateBridges2(ContractsIdxMapToContractsNodeInfo map[int]*ContractNodeInfo
 				return err
 			}
 			ContractsIdxMapToContractsNodeInfo[i].BridgeInfos = append(ContractsIdxMapToContractsNodeInfo[i].BridgeInfos, BridgeInfo{ObservationSource: observationSource, JuelsSource: juelsSource, RelayConfig: RelayConfig})
-			biMap[nodesInfo.OCR2Address] = append(biMap[nodesInfo.OCR2Address], BridgeInfo{ObservationSource: observationSource, JuelsSource: juelsSource, RelayConfig: RelayConfig})
 		}
 	}
 

--- a/tests/e2e/migration/ocr2_spec_migration_test.go
+++ b/tests/e2e/migration/ocr2_spec_migration_test.go
@@ -1,8 +1,8 @@
 package migration_test
 
 import (
-	"github.com/smartcontractkit/chainlink-terra/tests/e2e/utils"
 	"github.com/smartcontractkit/chainlink-terra/tests/e2e/common"
+	"github.com/smartcontractkit/chainlink-terra/tests/e2e/utils"
 	"os"
 	"time"
 
@@ -20,7 +20,7 @@ var _ = Describe("Terra OCRv2 @ocr-spec-migration", func() {
 	var migrateToVersion string
 
 	BeforeEach(func() {
-		state = tc.NewOCRv2State(1)
+		state = tc.NewOCRv2State(1, nodes)
 		By("Deploying the cluster", func() {
 			migrateToImage = os.Getenv("CHAINLINK_IMAGE_TO")
 			if migrateToImage == "" {
@@ -30,7 +30,7 @@ var _ = Describe("Terra OCRv2 @ocr-spec-migration", func() {
 			if migrateToVersion == "" {
 				Fail("Provide CHAINLINK_VERSION_TO variable: a version on which we migrate")
 			}
-			state.DeployCluster(nodes, common.ChainBlockTime, true)
+			state.DeployCluster(nodes, common.ChainBlockTime, true, utils.ContractsDir)
 			state.SetAllAdapterResponsesToTheSameValue(2)
 		})
 	})

--- a/tests/e2e/smoke/common/common.go
+++ b/tests/e2e/smoke/common/common.go
@@ -102,7 +102,6 @@ func NewOCRv2StateForSmoke(contracts int, nodes int) *OCRv2State {
 		for n := 1; n < nodes; n++ {
 			state.ContractsIdxMapToContractsNodeInfo[i].NodesIdx = append(state.ContractsIdxMapToContractsNodeInfo[i].NodesIdx, n)
 		}
-		log.Info().Interface("ContractsIdxMapToContractsNodeInfo[i].NodesIdx", state.ContractsIdxMapToContractsNodeInfo[i].NodesIdx).Msg("ContractsIdxMapToContractsNodeInfo[i].NodesIdx")
 	}
 	return state
 }
@@ -226,11 +225,10 @@ func (m *OCRv2State) DeployContracts2(contractsDir string) {
 			// The 0 index node is part of the nodes of all contracts
 			nodes = append(nodes, m.Nodes[0])
 			nodeKeysBundles = append(nodeKeysBundles, m.NodeKeysBundle[0])
-			for nodeIndex := range nodeIndexes {
+			for _, nodeIndex := range nodeIndexes {
 				nodes = append(nodes, m.Nodes[nodeIndex])
 				nodeKeysBundles = append(nodeKeysBundles, m.NodeKeysBundle[nodeIndex])
 			}
-			log.Info().Interface("nodeIndexes", nodeIndexes).Msg("nodeIndexes")
 			OCConfig, err := common.OffChainConfigParamsFromNodes(nodes, nodeKeysBundles)
 			Expect(err).ShouldNot(HaveOccurred())
 

--- a/tests/e2e/smoke/common/common.go
+++ b/tests/e2e/smoke/common/common.go
@@ -242,9 +242,9 @@ func (m *OCRv2State) DeployContracts(contractsDir string) {
 }
 
 func (m *OCRv2State) SetAllAdapterResponsesToTheSameValue(response int) {
-	for _, contract := range m.Contracts {
-		for _, node := range m.Nodes {
-			nodeContractPairID, err := common.BuildNodeContractPairID(node, contract.OCR2.Address())
+	for _, contractNodeInfo := range m.ContractsNodeSetup {
+		for _, node := range contractNodeInfo.Nodes {
+			nodeContractPairID, err := common.BuildNodeContractPairID(node, contractNodeInfo.OCR2Address)
 			Expect(err).ShouldNot(HaveOccurred())
 			path := fmt.Sprintf("/%s", nodeContractPairID)
 			m.Err = m.MockServer.SetValuePath(path, response)

--- a/tests/e2e/smoke/gauntlet_test.go
+++ b/tests/e2e/smoke/gauntlet_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Terra Gauntlet @gauntlet", func() {
 			state.NodeKeysBundle, state.Err = common.CreateNodeKeysBundle(state.Nodes)
 			Expect(state.Err).ShouldNot(HaveOccurred())
 
-			state.OCConfig, state.Err = common.OffChainConfigParamsFromNodes(state.Nodes, state.NodeKeysBundle)
+			_, state.Err = common.OffChainConfigParamsFromNodes(state.Nodes, state.NodeKeysBundle)
 			Expect(state.Err).ShouldNot(HaveOccurred())
 
 			// Remove the stuff below when the token:deploy command is fixed to work for automated testing

--- a/tests/e2e/smoke/gauntlet_test.go
+++ b/tests/e2e/smoke/gauntlet_test.go
@@ -28,15 +28,17 @@ var _ = Describe("Terra Gauntlet @gauntlet", func() {
 			gd = &e2e.GauntletDeployer{
 				Version: "local",
 			}
-			state = tc.NewOCRv2State(1)
+			state = tc.NewOCRv2State(1, 1)
 			state.DeployEnv(1, common.ChainBlockTime, false)
 			state.SetupClients()
 			if state.Nets.Default.ContractsDeployed() {
 				err := state.LoadContracts()
 				Expect(err).ShouldNot(HaveOccurred())
 			}
+			state.NodeKeysBundle, state.Err = common.CreateNodeKeysBundle(state.Nodes)
+			Expect(state.Err).ShouldNot(HaveOccurred())
 
-			state.OCConfig, state.NodeKeysBundle, state.Err = common.DefaultOffChainConfigParamsFromNodes(state.Nodes)
+			state.OCConfig, state.Err = common.OffChainConfigParamsFromNodes(state.Nodes, state.NodeKeysBundle)
 			Expect(state.Err).ShouldNot(HaveOccurred())
 
 			// Remove the stuff below when the token:deploy command is fixed to work for automated testing

--- a/tests/e2e/smoke/ocr2_proxy_test.go
+++ b/tests/e2e/smoke/ocr2_proxy_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Terra OCRv2 Proxy @ocr_proxy", func() {
 	var state *tc.OCRv2State
 
 	BeforeEach(func() {
-		state = tc.NewOCRv2State(1)
+		state = tc.NewOCRv2State(1, 5)
 		By("Deploying the cluster", func() {
 			state.DeployCluster(5, common.ChainBlockTime, false, utils.ContractsDir)
 			state.SetAllAdapterResponsesToTheSameValue(2)

--- a/tests/e2e/smoke/ocr2_test.go
+++ b/tests/e2e/smoke/ocr2_test.go
@@ -15,15 +15,15 @@ var _ = Describe("Terra OCRv2 @ocr2", func() {
 	var state *tc.OCRv2State
 
 	BeforeEach(func() {
-		state = tc.NewOCRv2State(1)
+		state = tc.NewOCRv2StateForSmoke(1, 5)
 		By("Deploying the cluster", func() {
-			state.DeployCluster(5, common.ChainBlockTime, false, utils.ContractsDir)
+			state.DeployCluster2(5, common.ChainBlockTime, false, utils.ContractsDir)
 			state.SetAllAdapterResponsesToTheSameValue(2)
 		})
 	})
 
 	Describe("with Terra OCR2", func() {
-		It("performs OCR2 round", func() {
+		FIt("performs OCR2 round", func() {
 			state.ValidateAllRounds(time.Now(), tc.NewRoundCheckTimeout, 10, false)
 		})
 	})

--- a/tests/e2e/smoke/ocr2_test.go
+++ b/tests/e2e/smoke/ocr2_test.go
@@ -15,15 +15,15 @@ var _ = Describe("Terra OCRv2 @ocr2", func() {
 	var state *tc.OCRv2State
 
 	BeforeEach(func() {
-		state = tc.NewOCRv2StateForSmoke(1, 5)
+		state = tc.NewOCRv2State(1, 5)
 		By("Deploying the cluster", func() {
-			state.DeployCluster2(5, common.ChainBlockTime, false, utils.ContractsDir)
+			state.DeployCluster(5, common.ChainBlockTime, false, utils.ContractsDir)
 			state.SetAllAdapterResponsesToTheSameValue(2)
 		})
 	})
 
 	Describe("with Terra OCR2", func() {
-		FIt("performs OCR2 round", func() {
+		It("performs OCR2 round", func() {
 			state.ValidateAllRounds(time.Now(), tc.NewRoundCheckTimeout, 10, false)
 		})
 	})

--- a/tests/e2e/soak/soak_test.go
+++ b/tests/e2e/soak/soak_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Terra OCRv2 soak test @ocr2-soak", func() {
 	var state *tc.OCRv2State
 
 	BeforeEach(func() {
-		state = tc.NewOCRv2State(30)
+		state = tc.NewOCRv2State(30, 5)
 		By("Deploying the cluster", func() {
 			state.DeployCluster(5, common.ChainBlockTimeSoak, false, utils.ContractsDir)
 			state.SetAllAdapterResponsesToTheSameValue(2)


### PR DESCRIPTION
With this changes it's possible to deploy setups which require ocr2 contracts to have different nodes running the protocol. Until now all contracts had the same oracles reporting.