### PR TITLE
packages-ts/terra-sdk: add blockHeight, txIndex, txHash to Round

### DIFF
--- a/packages-ts/terra-sdk/test/index.test.ts
+++ b/packages-ts/terra-sdk/test/index.test.ts
@@ -1,6 +1,5 @@
 import { OCR2Feed, Round } from '../src'
 import { Int, WebSocketClient } from '@terra-money/terra.js'
-import exp = require('constants')
 
 describe('OCR2Feed', () => {
   it('parseLog', () => {
@@ -86,6 +85,9 @@ describe('OCR2Feed', () => {
       expect(got.epoch).toBeDefined()
       expect(got.aggregatorRoundId).toBeDefined()
       expect(got.observationsTS).toBeDefined()
+      expect(got.blockHeight).toBeDefined()
+      expect(got.txIndex).toBeDefined()
+      expect(got.txHash).toBeDefined()
     },
     120_000,
   )


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/36233/terra-sdk-solana-sdk-add-chain-timestamp-to-round

On-chain timestamp was requested, but that doesn't seem to be available on the subscription response. We do have block height though, as well as tx index and hash.